### PR TITLE
Fix SSL version since Reddit has disabled SSLv3

### DIFF
--- a/reddit.php
+++ b/reddit.php
@@ -678,7 +678,7 @@ class reddit{
         if ($auth){
             $options[CURLOPT_HTTPAUTH] = CURLAUTH_BASIC;
             $options[CURLOPT_USERPWD] = redditConfig::$CLIENT_ID . ":" . redditConfig::$CLIENT_SECRET;
-            $options[CURLOPT_SSLVERSION] = 3;
+            $options[CURLOPT_SSLVERSION] = 4;
             $options[CURLOPT_SSL_VERIFYPEER] = false;
             $options[CURLOPT_SSL_VERIFYHOST] = 2;
         }

--- a/reddit.php
+++ b/reddit.php
@@ -70,7 +70,7 @@ class reddit{
                                    redditConfig::$SCOPES,
                                    $state);
                     
-                //forward user to PayPal auth page
+                //forward user to Reddit auth page
                 header("Location: $urlAuth");
             }
         }


### PR DESCRIPTION
Seems Reddit have disabled SSLv3 in the wake of POODLE.

Similar discussion here for Paypal's IPN

http://stackoverflow.com/questions/26379773/paypal-ipn-acknowledgements-failing-with-ssl-routinesssl3-read-bytessslv3-aler